### PR TITLE
V1.1.1 - Bugfix and addition of breadcrumbs

### DIFF
--- a/album.lens
+++ b/album.lens
@@ -16,7 +16,12 @@
 					<meta property="og:image:height" content="{{ content.presets.medium_large.height }}" />
 					</koken:shift></koken:covers>
 				</koken:head>
-
+				
+				<koken:if true="settings.show_breadcrumbs">
+					<div class="breadcrumbs">
+						<koken:breadcrumbs separator="/" show_if_single="false" />
+					</div>
+				</koken:if>
 				<div id="albumhead" class="row">
 					<div class="col-md-12">
 						<div class="heading">

--- a/category.lens
+++ b/category.lens
@@ -11,8 +11,12 @@
 					<meta property="og:type" content="website" />
 					<meta property="og:url" content="{{ location.site_url }}{{ location.here }}" />
 				</koken:head>
-
-				<koken:breadcrumbs />
+				
+				<koken:if true="settings.show_breadcrumbs">
+					<div class="breadcrumbs">
+						<koken:breadcrumbs separator="/" show_if_single="false" />
+					</div>
+				</koken:if>
 				<div class="row">
 					<div class="col-md-12">
 						<h1>All content in category: {{ event.title }}</h1>

--- a/content.lens
+++ b/content.lens
@@ -14,7 +14,12 @@
 					<meta property="og:image:height" content="{{ content.presets.medium_large.height }}" />
 					<meta property="og:url" content="{{ content.url }}" />
 				</koken:head>
-
+				
+				<koken:if true="settings.show_breadcrumbs">
+					<div class="breadcrumbs">
+						<koken:breadcrumbs separator="/" show_if_single="false" />
+					</div>
+				</koken:if>
 				<div class="row">
 					<div class="col-sm-8">
 						<koken:link lightbox="true" title="View in lightbox">

--- a/css/style.css
+++ b/css/style.css
@@ -46,6 +46,7 @@ section .title h2 {background: #f3f3f3;padding: 0.9375rem;font-size: 1.5rem;font
 .ruleright {border-right:0.0625rem solid #eee;}
 /* Display dividing lines correctly in Koken Admin Panel */
 .home .container>i:last-child>.row {border-bottom: none;}
+.breadcrumbs { margin-bottom: 1rem; }
 @media (min-width: 768px) {
 	.back-to-top {right: 1.875rem;bottom: 2.5rem;}
 }

--- a/date.lens
+++ b/date.lens
@@ -11,8 +11,12 @@
 					<meta property="og:type" content="website" />
 					<meta property="og:url" content="{{ location.site_url }}{{ location.here }}" />
 				</koken:head>
-
-				<koken:breadcrumbs />
+				
+				<koken:if true="settings.show_breadcrumbs">
+					<div class="breadcrumbs">
+						<koken:breadcrumbs separator="/" show_if_single="false" />
+					</div>
+				</koken:if>
 				<div class="row">
 					<div class="col-md-12">
 						<h1>All content published in <koken:time /></h1>

--- a/essay.lens
+++ b/essay.lens
@@ -2,7 +2,12 @@
 
 	<section id="main">
 		<div class="container">
-			<koken:load limit="10" infinite="true">
+			<koken:load limit="10" infinite="true">				
+				<koken:if true="settings.show_breadcrumbs">
+					<div class="breadcrumbs">
+						<koken:breadcrumbs separator="/" show_if_single="false" />
+					</div>
+				</koken:if>
 					<div class="row">
 						<div class="col-md-12">
 							<article>

--- a/info.json
+++ b/info.json
@@ -71,6 +71,12 @@
               }
             ]
           }
+        },
+        "show_breadcrumbs": {
+          "label": "Show Breadcrumbs",
+          "type": "boolean",
+          "note": "Display Breadcrumbs on all sub-pages to enhance navigation",
+          "value": "false"
         }
       }
     },

--- a/js/main.js
+++ b/js/main.js
@@ -38,19 +38,24 @@ $(function() {
 		}, 'fast');
 	})
 
-
 	// Changes Facebook, Twitter and Google plus links to Icons
-	var fbnav = document.querySelector('[title="Facebook"]');
-	fbnav.innerHTML = '<i class="fa fa-facebook-official"></i><span class="sr-only">Facebook</span>'
-	fbnav.title = 'Facebook'
-	fbnav.target = '_blank'
-	var twnav = document.querySelector('[title="Twitter"]');
-	twnav.innerHTML = '<i class="fa fa-twitter"></i><span class="sr-only">Twitter</span>'
-	twnav.title = 'Twitter'
-	twnav.target = '_blank'
-	var gpnav = document.querySelector('[title="Google+"]');
-	gpnav.innerHTML = '<i class="fa fa-google-plus"></i><span class="sr-only">Google+</span>'
-	gpnav.title = 'Google+'
-	gpnav.target = '_blank'
+	if ( document.querySelector('[title="Facebook"]') ) {
+		var fbnav = document.querySelector('[title="Facebook"]');
+		fbnav.innerHTML = '<i class="fa fa-facebook-official"></i><span class="sr-only">Facebook</span>'
+		fbnav.title = 'Facebook'
+		fbnav.target = '_blank'
+	};
+	if ( document.querySelector('[title="Twitter"]') ) {
+		var twnav = document.querySelector('[title="Twitter"]');
+		twnav.innerHTML = '<i class="fa fa-twitter"></i><span class="sr-only">Twitter</span>'
+		twnav.title = 'Twitter'
+		twnav.target = '_blank'
+	};
+	if ( document.querySelector('[title="Google+"]') ) {
+		var gpnav = document.querySelector('[title="Google+"]');
+		gpnav.innerHTML = '<i class="fa fa-google-plus"></i><span class="sr-only">Google+</span>'
+		gpnav.title = 'Google+'
+		gpnav.target = '_blank'
+	};
 });
 

--- a/set.lens
+++ b/set.lens
@@ -16,7 +16,12 @@
 					<meta property="og:image:height" content="{{ content.presets.medium_large.height }}" />
 					</koken:shift></koken:covers>
 				</koken:head>
-
+				
+				<koken:if true="settings.show_breadcrumbs">
+					<div class="breadcrumbs">
+						<koken:breadcrumbs separator="/" show_if_single="false" />
+					</div>
+				</koken:if>
 				<div id="albumhead" class="row">
 					<div class="col-md-12">
 						<div class="heading">

--- a/tag.lens
+++ b/tag.lens
@@ -12,7 +12,11 @@
 					<meta property="og:url" content="{{ location.site_url }}{{ location.here }}" />
 				</koken:head>
 
-				<koken:breadcrumbs />
+				<koken:if true="settings.show_breadcrumbs">
+					<div class="breadcrumbs">
+						<koken:breadcrumbs separator="/" show_if_single="false" />
+					</div>
+				</koken:if>
 				<div class="row">
 					<div class="col-md-12">
 						<h1>All content tagged: #{{ event.title }}</h1>


### PR DESCRIPTION
* Rewritten navigation social icon replacement to fail gracefully when there are no social items present.
* Added an option to enable breadcrumbs on the following pages to enhance navigation:
  * Album
  * Category
  * Content
  * Date
  * Essay
  * Set
  * Tag